### PR TITLE
Fix Bioc Build Issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gscreend
 Type: Package
 Title: Analysis of pooled genetic screens
-Version: 1.7.1
+Version: 1.7.2
 Authors@R: c(
     person("Katharina", "Imkeller", email = "k.imkeller@dkfz.de", role = c("cre", "aut")),
     person("Wolfgang", "Huber", email = "wolfgang.huber@embl.de", role = "aut"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Encoding: UTF-8
 LazyData: false
 Depends: R (>= 3.6)
 Imports: SummarizedExperiment, nloptr, fGarch, methods, BiocParallel, graphics
-Suggests: knitr, testthat, rmarkdown
+Suggests: knitr, testthat, rmarkdown, BiocStyle
 VignetteBuilder: knitr
 RoxygenNote: 6.1.1
 biocViews: Software, StatisticalMethod, PooledScreens, CRISPR


### PR DESCRIPTION
Hi @imkeller 

Not sure if you know, but gscreend is currently failing to build at Bioconductor and is scheduled for deprecation (https://support.bioconductor.org/p/9156893/).

This patch just adds BiocStyle to the suggests field, which is all that's needed to fix the build problems.